### PR TITLE
fix-turn-state-indicators

### DIFF
--- a/frontend/src/components/game/CardBack.tsx
+++ b/frontend/src/components/game/CardBack.tsx
@@ -9,8 +9,8 @@ const CardBack = ({ onClick, isActive = false }: CardBackProps) => {
     const { profile } = useProfile()
     let classes = classNames(
         'w-20 h-32 border-2 rounded-md text-3xl text-center',
-        'border-green-700 bg-green-700',
-        { 'hover:bg-green-800': isActive },
+        { 'border-green-500 bg-green-700 hover:bg-green-900': isActive },
+        { 'border-green-700 bg-green-700': !isActive },
         { 'text-2xl w-20 h-32': profile.settings.cardSize === 1 },
         { 'text-4xl w-28 h-40': profile.settings.cardSize === 2 },
         { 'text-6xl w-36 h-48': profile.settings.cardSize === 3 },

--- a/frontend/src/components/game/PlayerHand.tsx
+++ b/frontend/src/components/game/PlayerHand.tsx
@@ -63,7 +63,7 @@ const PlayerHand = ({
                 <path d="M6 10.5a.75.75 0 0 1 .75.75v1.5a5.25 5.25 0 1 0 10.5 0v-1.5a.75.75 0 0 1 1.5 0v1.5a6.751 6.751 0 0 1-6 6.709v2.291h3a.75.75 0 0 1 0 1.5h-7.5a.75.75 0 0 1 0-1.5h3v-2.291a6.751 6.751 0 0 1-6-6.709v-1.5A.75.75 0 0 1 6 10.5Z" />
                 </svg>}
 
-                {turnState.stage === 'end' && (
+                {isTurn && turnState.stage === 'end' && (
                     <>
                         <Button
                             onClick={handleClickMeld}

--- a/frontend/src/components/game/Table.tsx
+++ b/frontend/src/components/game/Table.tsx
@@ -55,7 +55,8 @@ const Table = ({
                     <div>
                         <h1 className="text-xl font-bold">Discard Pile</h1>
                         <Card
-                            card={game.discard}
+                            card={{ suit: game.discard.suit, value: game.discard.value, isSelected: (game.playerOrder ===
+                                game.turnState.turnCounter && game.turnState.stage === 'start') ? true : false }}
                             onClick={handleClickDiscard}
                             isActive={
                                 game.playerOrder ===


### PR DESCRIPTION
the pickup and discard pile are highlighted in light green when you can pick up from them. The indicators of turn state, for both the start and end stage, are only shown to the player whose turn it is (fix)